### PR TITLE
Add automatic loading of the ipython autocomplete extension for python kernels

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -238,8 +238,8 @@ const Config = {
     },
     pythonKernelAutoReload: {
       order: 26,
-      title: "Python AutoReload Extension settings",
-      description: "Whether or not to load the autocomplete extension on the launch of any ipython kernel",
+      title: "Python autoreload extension options",
+      description: "Whether or not to load the autocomplete extension on the launch of any ipython kernel (requires kernel restart)",
       type: "string",
       enum: [
         {
@@ -248,7 +248,7 @@ const Config = {
         },
         {
           value: "explicit",
-          description: "Explicit, only for modules imported with magic aimport",
+          description: "Explicit, only for modules imported with magic %aimport",
         },
         {
           value: "off",
@@ -260,7 +260,7 @@ const Config = {
     pythonKernelAutoReloadPrint: {
       order: 27,
       title: "Display autoreload activity",
-      description: "If true autoreload activity will be shown, set to silent to hide",
+      description: "If true autoreload activity will be printed, disable to hide (requires kernel restart)",
       type: "boolean",
       default: true,
     },

--- a/lib/zmq-kernel.js
+++ b/lib/zmq-kernel.js
@@ -163,23 +163,27 @@ export default class ZMQKernel extends KernelTransport {
       log("KernelManager: Executing startup code for kernel:", this.displayName);
       this.execute(kernelCode + "\n", (message, channel) => {});
     }
+
+    // For ipython kernels - configure the autcomplete extension
     if (this.language == "python") {
-      log("KernelManager: attempting to load autoreload"  );
+      log("KernelManager: Configuring autocomplete for python"  );
       const autoReloadConfig = atom.config.get("hydrogen-next.pythonKernelAutoReload");
-      log("KernelManager: attempting to load autoreload", autoReloadConfig);
       if (autoReloadConfig !== "off"){
-        log("KernelManager: autoreload is not off!");
+        log("KernelManager: Loading autoreload extension");
+        this.execute("%load_ext autoreload" + "\n" , (message, channel) => {});
         const autoReloadConfigPrint = atom.config.get("hydrogen-next.pythonKernelAutoReloadPrint");
+        //configure with or without the print option to display extension activity
         if (autoReloadConfigPrint) {
-          const kernelCode =  "%load_ext autoreload" + "\n"  +  "%autoreload " + autoReloadConfig + " --print \n";
+          const kernelCode =  "%autoreload " + autoReloadConfig + " --print \n";
           this.execute(kernelCode, (message, channel) => {});
+          log("KernelManager: autocomplete")
         } else {
-          const kernelCode =  "%load_ext autoreload" + "\n"  +  "%autoreload " + autoReloadConfig + " \n";
+          const kernelCode =  "%autoreload " + autoReloadConfig + " \n";
           this.execute(kernelCode, (message, channel) => {});
         }
 
       }
-  }
+    }
   }
 
   shutdown() {


### PR DESCRIPTION
Hi, 

Thanks for implementing the autocomplete for each language, but unfortunately it didn't quite go far enough as entering the autocomplete settings across multiple PCs is a bit annoying. 

This is also standard across a few other Python IDEs such as Spyder, where autoreload is loaded by its kernels automatically.  So I thought it might make sense to bring Hydrogen-Next in line with that. 

Rather than submit another feature request, I thought I'd give it a go myself. 

I've added two config options. One is for the options for autoreload. This can be off, all or explicit as defined in the [autoreload documentation ](https://ipython.readthedocs.io/en/stable/config/extensions/autoreload.html#magic-autoreload). The other configures whether or not the extension will print its activity. 

<img width="341" height="190" alt="image" src="https://github.com/user-attachments/assets/7a63d528-1760-4ee5-8b74-6b974bfbae25" />

The config is then loaded within the _executeStartupCode function and executed. I thought about adding another function for this, but I wasn't sure what the best practice would be. 

Feel free to refactor all of this to improve it. I pretty much exclusively use python, so my js is not the best. 

Thanks in advance! 